### PR TITLE
fix: absolute $HOME paths, reorder rbenv setup, add return void

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ TODO: Add a short summary of this module.
 - `p6df::modules::ruby::home::symlink()`
 - `p6df::modules::ruby::init(_module, dir)`
   - Args:
-    - _module - 
-    - dir - 
+    - _module -
+    - dir -
 - `p6df::modules::ruby::langs()`
 - `p6df::modules::ruby::vscodes()`
 - `p6df::modules::ruby::vscodes::config()`

--- a/init.zsh
+++ b/init.zsh
@@ -28,12 +28,14 @@ p6df::modules::ruby::deps() {
 ######################################################################
 p6df::modules::ruby::home::symlink() {
 
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-ruby/share/.gemrc" ".gemrc"
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-ruby/share/.riplrc" ".riplrc"
-
   p6_dir_mk "$P6_DFZ_SRC_DIR/rbenv/rbenv/plugins"
   p6_file_symlink "$P6_DFZ_SRC_DIR/rbenv/ruby-build" "$P6_DFZ_SRC_DIR/rbenv/rbenv/plugins/ruby-build"
   p6_file_symlink "$P6_DFZ_SRC_DIR/jf/rbenv-gemset" "$P6_DFZ_SRC_DIR/rbenv/rbenv/plugins/rbenv-gemset"
+
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-ruby/share/.gemrc" "$HOME/.gemrc"
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-ruby/share/.riplrc" "$HOME/.riplrc"
+
+  p6_return_void
 }
 
 ######################################################################


### PR DESCRIPTION
Fix symlink targets to use absolute $HOME. Reorder: rbenv plugin setup before gem config symlinks. Add missing p6_return_void.