### PR TITLE
fix(ruby): fix prompt::env env var and correct indentation in prompt::runtime

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -170,13 +170,12 @@ p6df::modules::ruby::prompt::runtime() {
 
   local gemset=$(rbenv gemset active 2>/dev/null | p6_filter_column_pluck 1)
 
-    # "rbenv_root:\t  $RBENV_ROOT"
-    local str=""
-    if p6_string_blank_NOT "$gemset" && ! p6_string_eq "$gemset" "no"; then
-      str="$(p6_string_space_pad "gemset:" 16)$gemset"
-    fi
+  local str=""
+  if p6_string_blank_NOT "$gemset" && ! p6_string_eq "$gemset" "no"; then
+    str="$(p6_string_space_pad "gemset:" 16)$gemset"
+  fi
 
-    p6_return_str "$str"
+  p6_return_str "$str"
 }
 
 ######################################################################
@@ -213,6 +212,6 @@ p6df::modules::ruby::prompt::lang() {
 ######################################################################
 p6df::modules::ruby::prompt::env() {
 
-  p6_return_words 'ruby' "$"
+  p6_return_words 'ruby' '$RBENV_ROOT'
 }
 


### PR DESCRIPTION
## What
Fix `prompt::env` to return `'$RBENV_ROOT'` instead of a broken `"$"`, and fix incorrect indentation in `prompt::runtime` where code was indented one extra level.

## Why
The return value in `prompt::env` was broken — returning a literal `"$"` instead of `'$RBENV_ROOT'`. The indentation in `prompt::runtime` was also off (extra level of indentation) making the code harder to read and inconsistent with the rest of the file.

## Test plan
- Verified diff is correct
- `prompt::env` now returns `ruby $RBENV_ROOT` as expected
- Indentation in `prompt::runtime` now matches function body style

## Dependencies
None